### PR TITLE
fix #3: variable highlighting was one line too high

### DIFF
--- a/src/editor.fsx
+++ b/src/editor.fsx
@@ -348,7 +348,7 @@ let highlighterProvider = {
                 return
                     o.Data.Uses |> Array.map (fun d ->
                         let res = createEmpty<languages.DocumentHighlight> 
-                        res.range <- Range (float d.StartLine - 1., float d.StartColumn, float d.EndLine - 1., float d.EndColumn) |> unbox
+                        res.range <- Range (float d.StartLine, float d.StartColumn, float d.EndLine, float d.EndColumn) |> unbox
                         res.kind <- (0 |> unbox)
                         res )
                     


### PR DESCRIPTION
see https://github.com/ionide/ionide-web/issues/3
after this change:
![image](https://cloud.githubusercontent.com/assets/4236651/17574137/0e6c9e04-5f5f-11e6-8e4c-7d07fa6ad1a5.png)
